### PR TITLE
Add oRPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ _A curated list of awesome TypeScript Typesafe_
 - [stepci/garph](https://github.com/stepci/garph) - Fullstack GraphQL Framework for TypeScript.
 - [BetterTyped/hyper-fetch](https://github.com/BetterTyped/hyper-fetch) - Hyper Fetch is a data-exchange framework focusing on type-safe design and ease of use.
 - [type-predicate-generator](https://github.com/peter-leonov/type-predicate-generator) - 100% type safe predicates for JSON APIs with blazing performance
-- [unnoq/orpc]([https://github.com/trpc/trpc](https://github.com/unnoq/orpc)) - Typesafe APIs Made Simple, with first-class OpenAPI support.
+- [unnoq/orpc](https://github.com/unnoq/orpc) - Typesafe APIs Made Simple, with first-class OpenAPI support.
 
 <a name="graphql"/>
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ _A curated list of awesome TypeScript Typesafe_
 - [stepci/garph](https://github.com/stepci/garph) - Fullstack GraphQL Framework for TypeScript.
 - [BetterTyped/hyper-fetch](https://github.com/BetterTyped/hyper-fetch) - Hyper Fetch is a data-exchange framework focusing on type-safe design and ease of use.
 - [type-predicate-generator](https://github.com/peter-leonov/type-predicate-generator) - 100% type safe predicates for JSON APIs with blazing performance
+- [unnoq/orpc]([https://github.com/trpc/trpc](https://github.com/unnoq/orpc)) - Typesafe APIs Made Simple, with first-class OpenAPI support.
 
 <a name="graphql"/>
 


### PR DESCRIPTION
oRPC new type-safe api builder, RPC & OpenAPI combination. https://github.com/unnoq/orpc
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `unnoq/orpc` to the APIs section in `README.md`, highlighting its type-safe API and OpenAPI support.
> 
>   - **README Update**:
>     - Adds `unnoq/orpc` to the APIs section in `README.md`. Described as "Typesafe APIs Made Simple, with first-class OpenAPI support."
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jellydn%2Fawesome-typesafe&utm_source=github&utm_medium=referral)<sup> for 799c7a8499505d65e055a8d21bb519731f9bddcc. You can [customize](https://app.ellipsis.dev/jellydn/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new entry for "unnoq/orpc" to the APIs section of the curated list in the README with a correct repository link and description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->