### PR TITLE
Add defectless library to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ _A curated list of awesome TypeScript Typesafe_
 - [supermacro/neverthrow](https://github.com/supermacro/neverthrow) - Type-Safe Errors for JavaScript & TypeScript.
 - [venables/typed-route-handler](https://github.com/venables/typed-route-handler) - Type-safe API Route Handlers for Next.js.
 - [true-myth/true-myth](https://github.com/true-myth/true-myth) - A library for safer and smarter error- and "nothing"-handling in TypeScript.
+- [sapphire-cms/defectless](https://github.com/sapphire-cms/defectless) - Provides a "Promise with a typed error channel," enabling the creation of predictable, bulletproof TypeScript applications without the chaos of untyped exceptions.
 - [ecyrbe/zodios](https://github.com/ecyrbe/zodios) - A complete typesafe wrapper around Zod for a boilerplate-free, typesafe, and DRY experience.
 - [g-plane/typed-query-selector](https://github.com/g-plane/typed-query-selector) - Better typed `querySelector` and `querySelectorAll`.
 - [tatethurston/nextjs-routes](https://github.com/tatethurston/nextjs-routes) - Type safe routing for Next.js.


### PR DESCRIPTION
Hello @jellydn 

I have noticed you have `Neverthrow` and `True-Myth` in your list of typesafe libraries. I suggest to add `Defectless`, which responds to the same need, with a slightly different approach.

`Neverthrow` is no longer maintained. Defectless was born as its fork, but later became a totaly different library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation to include a new library reference in the curated collection of TypeScript typesafe solutions. This addition features complete repository information and descriptive details, providing developers with expanded options to explore and evaluate additional tools available in the ecosystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->