### PR TITLE
Add har2sdk to APIs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ _A curated list of awesome TypeScript Typesafe_
 - [unnoq/orpc](https://github.com/unnoq/orpc) - Typesafe APIs Made Simple, with first-class OpenAPI support.
 - [cloudflare/capnweb](https://github.com/cloudflare/capnweb) - JavaScript/TypeScript-native, low-boilerplate, object-capability RPC system.
 - [encoredev/encore](https://github.com/encoredev/encore) - Type-safe backend framework with declarative infrastructure and automatic API client generation.
+- [har2sdk](https://har2sdk.vercel.app/) - Generate a typed TypeScript fetch SDK from a captured HAR (Chrome / Firefox network export) — semantic method naming, resource grouping, and auth detection. Skip the OpenAPI intermediate.
 
 <a name="graphql"/>
 


### PR DESCRIPTION
Adds [har2sdk](https://har2sdk.vercel.app/) to the `1. Libraries → APIs` section.

har2sdk takes a browser HAR (Chrome / Firefox network export) and generates a typed TypeScript fetch SDK with:
- Semantic method naming (`client.users.create({...})`, not `request('POST', '/v1/users', ...)`)
- Resource grouping by URL path
- Auth header detection (`new SDK({ apiKey })` constructor)
- Type inference from heterogeneous response samples

Fits alongside type-predicate-generator, hyper-fetch, and ts-rest — the type-safety angle is the wedge.

- Live URL: https://har2sdk.vercel.app/
- Source: https://github.com/SolvoHQ/har2sdk
- Free, no signup. Client-side secret-scrub before upload (Authorization / X-API-Key / JWT / AWS / Stripe key shapes are redacted in-browser before any network call).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added entry for a TypeScript SDK generator tool that creates typed fetch SDKs from HAR files with semantic method naming and resource grouping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jellydn/awesome-typesafe/pull/19)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->