### PR TITLE
docs: add Flue and eve to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ _A curated list of awesome TypeScript Typesafe_
 <a name="ai"/>
 
 ### AI
+- [withastro/flue](https://github.com/withastro/flue) - The sandbox agent framework from Astro.
+- [vercel/eve](https://github.com/vercel/eve) - The framework for building agents.
 - [Mastra](https://github.com/mastra-ai/mastra) - Mastra is an opinionated TypeScript framework that helps you build AI applications and features quickly.
 
 <a name="others"/>


### PR DESCRIPTION
## What

- Added Flue and eve to the AI section of `README.md`
- Kept the existing AI framework entry for Mastra

## Why

- The list should include the newer agent framework launches that fit the repository's typesafe tooling focus
- These additions make the AI section more complete and current

## How

- Updated the Markdown list under `### AI`
- Linked to the official GitHub repositories for both projects

## Checklist

- [ ] Tests added or updated
- [x] Documentation updated
- [x] No breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the AI section of the README with two additional entries.
  * Reordered the list so the existing entry now appears after the new items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->