### PR TITLE
Add enum-plus to the Others section

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ _A curated list of awesome TypeScript Typesafe_
 - [edmundhung/conform](https://github.com/edmundhung/conform) - A type-safe form validation library utilizing web fundamentals to progressively enhance HTML Forms with full support for server frameworks like Remix and Next.js.
 - [nicojs/typed-inject](https://github.com/nicojs/typed-inject) - Type safe dependency injection for TypeScript.
 - [arcanis/clipanion](https://github.com/arcanis/clipanion) - Type-safe CLI library / framework with no runtime dependencies.
+- [shijistar/enum-plus](https://github.com/shijistar/enum-plus) - Type-safe drop-in replacement for native TypeScript `enum`, with metadata, UI binding, and i18n.
 
 ## Contributors ✨
 


### PR DESCRIPTION
## WHAT

[enum-plus](https://github.com/shijistar/enum-plus) is a fully-type-safe, drop-in replacement for native TypeScript `enum` (keeps tuple/enum-style typing, with graceful type-degradation across TS versions). Adds runtime capabilities: display labels, metadata, `findBy`/`toList`/`toMap` helpers, UI binding and a plugin-based i18n system for React/Vue/Next. 0 dependencies, MIT.

## Evidence of maintenance
- npm v3.3.0, 60 releases, 0 dependencies, built-in TS type declarations
- 2xx stars, 512 commits, active updates, vitest e2e + codecov coverage
- Repo: https://github.com/shijistar/enum-plus
- Docs: https://shijistar.github.io/enum-plus
- Code coverage: https://app.codecov.io/gh/shijistar/enum-plus/tree/master/src 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added `enum-plus` to the list of recommended alternatives to native enums, highlighting type safety, metadata, UI binding, and internationalization support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->