### PR TITLE
docs: add ArkEnv to Awesome Typesafe

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ _A curated list of awesome TypeScript Typesafe_
 - [SeasonedSoftware/domain-functions](https://github.com/SeasonedSoftware/domain-functions) - Decouple your business logic from your framework with first-class type inference from end to end.
 - [KATT/envsafe](https://github.com/KATT/envsafe) - Makes sure you don't accidentally deploy apps with missing or invalid environment variables.
 - [dmno-dev/varlock](https://github.com/dmno-dev/varlock) - AI-safe .env files with schema-driven validation, secret handling, and leak scanning.
+- [yamcodes/arkenv](https://github.com/yamcodes/arkenv) - Typesafe environment variable validation with ArkType, Zod, Valibot, or any Standard Schema library.
 - [supermacro/neverthrow](https://github.com/supermacro/neverthrow) - Type-Safe Errors for JavaScript & TypeScript.
 - [venables/typed-route-handler](https://github.com/venables/typed-route-handler) - Type-safe API Route Handlers for Next.js.
 - [true-myth/true-myth](https://github.com/true-myth/true-myth) - A library for safer and smarter error- and "nothing"-handling in TypeScript.


### PR DESCRIPTION
## What

- Added [`yamcodes/arkenv`](https://github.com/yamcodes/arkenv) to the Awesome Typesafe list under the Others section.
- Linked to the GitHub repo (not npm) and summarized its typesafe env-var validation.

## Why

- ArkEnv fits the list: it infers types from your schema and validates environment variables before the app starts.
- It sits next to `envsafe` and `varlock` as an env-focused typesafe library. The default schema is ArkType; Zod, Valibot, and any Standard Schema library are first-class too.

## How

- Updated `README.md` with a single new list item near `envsafe` and `varlock` in Others.
- Format: `- [owner/repo](url) - Description.` Description starts with a capital and ends with a period.
- Kept the change documentation-only. One suggestion, one PR.

## Checklist

- [ ] Tests added or updated
- [x] Documentation updated
- [x] No breaking changes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added arkenv to the list of available environment variable validation libraries.
  * Noted support for ArkType, Zod, Valibot, and Standard Schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->